### PR TITLE
Rule Manager: Make LoadRules() serialization and introduce recover lo…

### DIFF
--- a/core/circuitbreaker/rule_manager.go
+++ b/core/circuitbreaker/rule_manager.go
@@ -30,10 +30,11 @@ type CircuitBreakerGenFunc func(r *Rule, reuseStat interface{}) (CircuitBreaker,
 var (
 	cbGenFuncMap = make(map[Strategy]CircuitBreakerGenFunc, 4)
 
-	breakerRules = make(map[string][]*Rule)
-	breakers     = make(map[string][]CircuitBreaker)
-	updateMux    = &sync.RWMutex{}
-	currentRules = make([]*Rule, 0)
+	breakerRules  = make(map[string][]*Rule)
+	breakers      = make(map[string][]CircuitBreaker)
+	updateMux     = &sync.RWMutex{}
+	currentRules  = make([]*Rule, 0)
+	updateRuleMux = new(sync.Mutex)
 
 	stateChangeListeners = make([]StateChangeListener, 0)
 )
@@ -132,9 +133,9 @@ func ClearRules() error {
 // error: was designed to indicate whether occurs the error.
 func LoadRules(rules []*Rule) (bool, error) {
 	// TODO in order to avoid invalid update, should check consistent with last update rules
-	updateMux.RLock()
+	updateRuleMux.Lock()
+	defer updateRuleMux.Unlock()
 	isEqual := reflect.DeepEqual(currentRules, rules)
-	updateMux.RUnlock()
 	if isEqual {
 		logging.Info("[CircuitBreaker] Load rules is the same with current rules, so ignore load operation.")
 		return false, nil
@@ -230,20 +231,20 @@ func onRuleUpdate(rules []*Rule) (err error) {
 	}
 
 	start := util.CurrentTimeNano()
-	updateMux.Lock()
-	defer func() {
-		updateMux.Unlock()
-		if r := recover(); r != nil {
-			return
-		}
-		logging.Debug("[CircuitBreaker onRuleUpdate] Time statistics(ns) for updating circuit breaker rule", "timeCost", util.CurrentTimeNano()-start)
-		logRuleUpdate(newBreakerRules)
-	}()
+
+	updateMux.RLock()
+	breakersClone := make(map[string][]CircuitBreaker, len(newBreakerRules))
+	for res, tcs := range breakers {
+		resTcClone := make([]CircuitBreaker, 0, len(tcs))
+		resTcClone = append(resTcClone, tcs...)
+		breakersClone[res] = resTcClone
+	}
+	updateMux.RUnlock()
 
 	for res, resRules := range newBreakerRules {
 		emptyCircuitBreakerList := make([]CircuitBreaker, 0, 0)
 		for _, r := range resRules {
-			oldResCbs := breakers[res]
+			oldResCbs := breakersClone[res]
 			if oldResCbs == nil {
 				oldResCbs = emptyCircuitBreakerList
 			}
@@ -255,7 +256,7 @@ func onRuleUpdate(rules []*Rule) (err error) {
 				equalOldCb := oldResCbs[equalIdx]
 				insertCbToCbMap(equalOldCb, res, newBreakers)
 				// remove old cb from oldResCbs
-				breakers[res] = append(oldResCbs[:equalIdx], oldResCbs[equalIdx+1:]...)
+				breakersClone[res] = append(oldResCbs[:equalIdx], oldResCbs[equalIdx+1:]...)
 				continue
 			}
 
@@ -278,7 +279,7 @@ func onRuleUpdate(rules []*Rule) (err error) {
 			}
 
 			if reuseStatIdx >= 0 {
-				breakers[res] = append(oldResCbs[:reuseStatIdx], oldResCbs[reuseStatIdx+1:]...)
+				breakersClone[res] = append(oldResCbs[:reuseStatIdx], oldResCbs[reuseStatIdx+1:]...)
 			}
 			insertCbToCbMap(cb, res, newBreakers)
 		}
@@ -292,10 +293,14 @@ func onRuleUpdate(rules []*Rule) (err error) {
 		}
 	}
 
+	updateMux.Lock()
 	breakerRules = newBreakerRules
 	breakers = newBreakers
 	currentRules = rules
+	updateMux.Unlock()
 
+	logging.Debug("[CircuitBreaker onRuleUpdate] Time statistics(ns) for updating circuit breaker rule", "timeCost", util.CurrentTimeNano()-start)
+	logRuleUpdate(newBreakerRules)
 	return nil
 }
 

--- a/core/flow/rule_manager_test.go
+++ b/core/flow/rule_manager_test.go
@@ -263,7 +263,7 @@ func Test_buildRulesOfRes(t *testing.T) {
 			MaxQueueingTimeMs:      10,
 		}
 		assert.True(t, len(tcMap["abc1"]) == 0)
-		tcs := buildRulesOfRes("abc1", []*Rule{r1, r2})
+		tcs := buildRulesOfRes("abc1", []*Rule{r1, r2}, tcMap)
 		assert.True(t, len(tcs) == 2)
 		assert.True(t, tcs[0].BoundRule() == r1)
 		assert.True(t, tcs[1].BoundRule() == r2)
@@ -413,7 +413,7 @@ func Test_buildRulesOfRes(t *testing.T) {
 			StatIntervalInMs:       50000,
 		}
 
-		tcs := buildRulesOfRes("abc1", []*Rule{r12, r22, r32, r42})
+		tcs := buildRulesOfRes("abc1", []*Rule{r12, r22, r32, r42}, tcMap)
 		assert.True(t, len(tcs) == 4)
 
 		assert.True(t, tcs[0].BoundRule() == r12)

--- a/core/isolation/rule_manager.go
+++ b/core/isolation/rule_manager.go
@@ -25,17 +25,18 @@ import (
 )
 
 var (
-	ruleMap      = make(map[string][]*Rule)
-	rwMux        = &sync.RWMutex{}
-	currentRules = make([]*Rule, 0)
+	ruleMap       = make(map[string][]*Rule)
+	rwMux         = &sync.RWMutex{}
+	currentRules  = make([]*Rule, 0)
+	updateRuleMux = new(sync.Mutex)
 )
 
 // LoadRules loads the given isolation rules to the rule manager, while all previous rules will be replaced.
 // the first returned value indicates whether do real load operation, if the rules is the same with previous rules, return false
 func LoadRules(rules []*Rule) (bool, error) {
-	rwMux.RLock()
+	updateRuleMux.Lock()
+	defer updateRuleMux.Unlock()
 	isEqual := reflect.DeepEqual(currentRules, rules)
-	rwMux.RUnlock()
 	if isEqual {
 		logging.Info("[Isolation] Load rules is the same with current rules, so ignore load operation.")
 		return false, nil
@@ -60,12 +61,6 @@ func onRuleUpdate(rules []*Rule) (err error) {
 	}
 
 	start := util.CurrentTimeNano()
-	rwMux.Lock()
-	defer func() {
-		rwMux.Unlock()
-		logging.Debug("[Isolation LoadRules] Time statistic(ns) for updating isolation rule", "timeCost", util.CurrentTimeNano()-start)
-		logRuleUpdate(m)
-	}()
 
 	for res, rs := range m {
 		if len(rs) > 0 {
@@ -73,8 +68,13 @@ func onRuleUpdate(rules []*Rule) (err error) {
 			misc.RegisterRuleCheckSlotForResource(res, DefaultSlot)
 		}
 	}
+	rwMux.Lock()
 	ruleMap = m
 	currentRules = rules
+	rwMux.Unlock()
+
+	logging.Debug("[Isolation LoadRules] Time statistic(ns) for updating isolation rule", "timeCost", util.CurrentTimeNano()-start)
+	logRuleUpdate(m)
 	return
 }
 

--- a/core/system/rule_manager_test.go
+++ b/core/system/rule_manager_test.go
@@ -73,12 +73,15 @@ func TestClearRules(t *testing.T) {
 	})
 
 	t.Run("NoEmptyOriginRuleMap", func(t *testing.T) {
-		r := map[MetricType][]*Rule{
-			InboundQPS:  {&Rule{MetricType: InboundQPS, TriggerCount: 1}},
-			Concurrency: {&Rule{MetricType: Concurrency, TriggerCount: 2}},
+		r := []*Rule{
+			{MetricType: InboundQPS, TriggerCount: 1},
+			{MetricType: Concurrency, TriggerCount: 2},
 		}
-		ruleMap = r
-		err := ClearRules()
+		isOK, err := LoadRules(r)
+		assert.Equal(t, true, isOK)
+		assert.Nil(t, err)
+		assert.Equal(t, 2, len(ruleMap))
+		err = ClearRules()
 		assert.Nil(t, err)
 		assert.Equal(t, 0, len(ruleMap))
 	})

--- a/ext/datasource/helper.go
+++ b/ext/datasource/helper.go
@@ -112,8 +112,8 @@ func SystemRulesUpdater(data interface{}) error {
 			fmt.Sprintf("Fail to type assert data to []system.Rule or []*system.Rule, in fact, data: %+v", data),
 		)
 	}
-	succ, err := system.LoadRules(rules)
-	if succ && err == nil {
+	_, err := system.LoadRules(rules)
+	if err == nil {
 		return nil
 	}
 	return NewError(


### PR DESCRIPTION
热点参数规则中，增加ParamKey配合context attachments map ,方便快速从大量的键值对中指定需要热点限流的值. (#355)

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
方便热点限流规则中，指定热点参数。
比如把系统参数、header中标定参数、业务参数，数据很多，不同业务需要的参数也不相同，加入把全部数据放入天、ctx.attachments  这样在规则中指定特点的key，很方便。

### Does this pull request fix one issue?
本次pr 已经增加ParamKey, 并且修改了对应的单元测试和example.
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
1. 规则增加ParamKey；
2. trafficShaper 也对应实现extractArg 接口，可以与已有的paramIndex 一起方便指定热点参数。

### Describe how to verify it
单元测试和example 中均验证过了

### Special notes for reviews
ParamKey 可以考虑变成[]string ，这样使用者除了指定单个参数外，还可以灵活的指定热点的规则。
例如ParamKey=[]string{"uid","merchant_id"} 这样可以让uid和merchant_id 作为联合参数作为热点。
